### PR TITLE
[FIX] Middleware cookie invalidation check fixed. 

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,23 +1,28 @@
 
-import axios from 'axios';
 import { NextResponse } from 'next/server'
 import { NextRequest } from 'next/server'
 import { cookies } from "next/headers";
- 
+
 // This function can be marked `async` if using `await` inside
 export async function middleware(request: NextRequest) {
     if (!request.cookies.has('Auth-Token')) {
-        return NextResponse.redirect(new URL('/login', request.url))
+        console.log("COOKIE NOT FOUND")
+        return NextResponse.redirect(new URL('/', request.url))
     }
     const auth = cookies().get('Auth-Token');
     let api_endpoint = process.env.NEXT_PUBLIC_API_URL?.concat("validate");
-    axios
-        .post(api_endpoint! , auth)
-        .catch(() => {
-            return NextResponse.redirect(new URL('/login', request.url))
-        })
+    const res = await fetch(api_endpoint!, {
+        headers: {
+            Cookie: `Auth-Token=${auth?.value};`
+        }
+    });
+
+    if (!res.ok) {
+        return NextResponse.redirect(new URL('/', request.url))
+    }
 }
 
 export const config = {
     matcher: ['/dashboard',]
-  }
+}
+


### PR DESCRIPTION
Cookie invalidation had 2 problems in the middleware.

1) Returned the redirect through a closure function which did nothing.
2) Used `axios` which doesnt work on the server side. Using standard `await fetch` now.